### PR TITLE
Remove default JWT secret, enforce env var

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -5,8 +5,11 @@ const jwt = require('jsonwebtoken');
 const userModel = require('../models/userModel');
 const db = require('../config/db');
 
-// Clé secrète pour les jetons JWT, avec une valeur par défaut
-const JWT_SECRET = process.env.JWT_SECRET || 'kaizenverse_secret_key';
+// Clé secrète pour les jetons JWT (obligatoire)
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+    throw new Error('JWT_SECRET environment variable is not defined');
+}
 
 // Gère l'inscription d'un nouvel utilisateur
 exports.register = async (req, res) => {

--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -1,8 +1,11 @@
 // Middleware pour la vérification des jetons d'authentification JWT
 
 const jwt = require('jsonwebtoken');
-// Récupère la clé secrète depuis les variables d'environnement ou utilise une valeur par défaut
-const JWT_SECRET = process.env.JWT_SECRET || 'kaizenverse_secret_key';
+// Récupère la clé secrète depuis les variables d'environnement
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+    throw new Error('JWT_SECRET environment variable is not defined');
+}
 
 // Fonction middleware pour vérifier le jeton JWT
 const verifyToken = (req, res, next) => {


### PR DESCRIPTION
## Summary
- ensure JWT_SECRET is defined at startup
- drop fallback 'kaizenverse_secret_key'

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685d372181a48322bd92bb00e2b97d49