### PR TITLE
Configure backend port via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# MSA Platform
+
+This repository contains the backend API and frontend application for the MSA educational platform.
+
+## Backend setup
+
+1. Install dependencies:
+   ```bash
+   cd backend && npm install
+   ```
+2. Configure environment variables in `backend/.env` (see `MONGODB_ATLAS_SETUP.md`).
+3. **Server port** – the backend listens on `PORT`. If this variable is not set, it defaults to `5000`.
+
+Start the backend using:
+```bash
+npm start
+```

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,9 @@
 const express = require('express');
 const cors = require('cors');
+const dotenv = require('dotenv');
 const authRoutes = require('./routes/authRoutes');
+
+dotenv.config();
 const postRoutes = require('./routes/postRoutes');
 const commentRoutes = require('./routes/commentRoutes');
 const messageRoutes = require('./routes/messageRoutes');
@@ -9,7 +12,7 @@ const quizRoutes = require('./routes/quizRoutes'); // Quiz routes
 const connectMongoDB = require('./config/mongodb'); // MongoDB connection
 
 const app = express();
-const PORT = 5000;
+const PORT = process.env.PORT || 5000;
 
 // Middlewares
 app.use(cors());


### PR DESCRIPTION
## Summary
- allow setting `PORT` in `backend/server.js`
- create root README documenting `PORT`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685d37219dc8832286df9fe6ff8e0b1b